### PR TITLE
Fix the rss link in the footer

### DIFF
--- a/templates/structure.html
+++ b/templates/structure.html
@@ -33,7 +33,7 @@
   <a href="https://twitter.com/projectatomic"><span class="fab fa-twitter"></span> Twitter</a>
   <a href="irc://irc.freenode.org:6667/#atomic"><span class="fas fa-comments"></span> IRC</a>
   <a href="https://github.com/projectatomic/atomic-site"><span class="fab fa-github"></span> GitHub</a>
-  <a href="http://www.projectatomic.io/public/feed.xml"><span class="fas fa-rss"></span> RSS</a>
+  <a href="http://www.projectatomic.io/blog/feed.xml"><span class="fas fa-rss"></span> RSS</a>
 </nav>
 <p>&copy; 2014&ndash;2018 Project Atomic. Sponsored by Red Hat, Inc.<p>
 </footer>


### PR DESCRIPTION
This was giving me a 404. Replace the link with the one
that is on the current website.