### PR TITLE
Fix an end tag

### DIFF
--- a/pages/talks/index.html
+++ b/pages/talks/index.html
@@ -35,7 +35,7 @@
 
 <p>Jan Pazdziora: <a href="https://www.youtube.com/watch?v=eWoFpOoA-tE">Minimizing workstation installation</a>
 
-<p>Kalev Lember: <a href="https://www.youtube.com/watch?v=Yc7lvkl5atE">Atomic Workstation<a/>
+<p>Kalev Lember: <a href="https://www.youtube.com/watch?v=Yc7lvkl5atE">Atomic Workstation</a>
 <a href="https://kalev.fedorapeople.org/slides/2018-devconf-Atomic-Workstation.pdf">Slides</a>
 
 <p>Jonathan Lebon: <a href="https://www.youtube.com/watch?v=7c3GdfhWzcc">Fearless Upgrades with Fedora Atomic Workstation</a>


### PR DESCRIPTION
I managed to typo an </a> in the talks page, causing a
stray empty link to appear for Kalev's talk. Fix this by
moving the / where it belongs.