### PR TITLE
Fix the "Get Started" link

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -19,7 +19,7 @@
   Atomic Host (AH) provides "immutable infrastructure" for deploying to hundreds or
   thousands of servers in your private or public cloud. Available in <b>Fedora Atomic Host,</b><b>CentOS Atomic Host,</b> <b>and Red Hat Atomic Host</b> editions depending on your platform and support needs.</p>
   <p>To balance the need between long-term stability and new features, we are providing different releases of Atomic Host for you to choose from.</p>
-  <p><a href='/download/'>Get Started</a></p>
+  <p><a href='/download'>Get Started</a></p>
 </section>
 
 <section>


### PR DESCRIPTION
One of the recent commits added a stray trailing /,
which was causing the link to not work anymore.